### PR TITLE
fix: Use mount_path to narrow down urls_for

### DIFF
--- a/lib/grape-swagger/rake/oapi_tasks.rb
+++ b/lib/grape-swagger/rake/oapi_tasks.rb
@@ -95,7 +95,7 @@ module GrapeSwagger
       def urls_for(api_class)
         api_class.routes
                  .map(&:path)
-                 .select { |e| e.include?('doc') }
+                 .grep(/#{GrapeSwagger::DocMethods.class_variable_get(:@@mount_path)}\(\.json\)$/)
                  .reject { |e| e.include?(':name') }
                  .map { |e| format_path(e) }
                  .map { |e| [e, ENV.fetch('resource', nil)].join('/').chomp('/') }

--- a/spec/lib/oapi_tasks_spec.rb
+++ b/spec/lib/oapi_tasks_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe GrapeSwagger::Rake::OapiTasks do
       namespace :otherItem do
         get '/'
       end
+
+      namespace :my_doc do
+        get '/'
+      end
     end
 
     class Base < Grape::API
@@ -115,7 +119,7 @@ RSpec.describe GrapeSwagger::Rake::OapiTasks do
         end
 
         it 'returns complete doc' do
-          expect(response['paths'].length).to eql 2
+          expect(response['paths'].length).to eql 3
         end
       end
     end
@@ -128,6 +132,16 @@ RSpec.describe GrapeSwagger::Rake::OapiTasks do
         expect(subject).to respond_to :oapi
         expect(subject.oapi).to be_a String
         expect(subject.oapi).not_to be_empty
+      end
+    end
+  end
+
+
+  describe '#urls_for' do
+    require 'pry'
+    describe 'match only the path to mount_path' do
+      it do
+        expect(subject.send(:urls_for, api_class)).to match_array ['/api/swagger_doc']
       end
     end
   end


### PR DESCRIPTION
## Overview

When you run `rake oapi:fetch`, All endpoints that include the path name doc will be caught.
Narrow down the target path using mount_path.

## I used it as a reference

- https://github.com/ruby-grape/grape-swagger/pull/877

## How to test

all test passed.